### PR TITLE
ci: set up publishing docker image

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,12 +2,7 @@ name: Docker Build and Push
 
 on:
   push:
-    branches: ["**"]
-  pull_request:
-    branches: ["**"]
-  # Uncomment below to only run on tags (releases)
-  # push:
-  #   tags: ["v*"]
+    tags: ["v*"]
 
 permissions:
   contents: read
@@ -33,4 +28,6 @@ jobs:
         with:
           context: .
           push: true
-          tags: ghcr.io/${{ github.repository }}:latest
+          tags: |
+            ghcr.io/${{ github.repository }}:latest
+            ghcr.io/${{ github.repository }}:${{ github.ref_name }}


### PR DESCRIPTION
Tested by temporarily making the GH action run on the PR branch instead of on tags. The image was successfully published: https://github.com/stacklok/toolhive-cloud-ui/pkgs/container/toolhive-cloud-ui     
  
To pull the image locally, you need to do this:

```bash
docker pull ghcr.io/stacklok/toolhive-cloud-ui:latest
```

if that does not work, you need to make sure that you are locally authenticated and that your token has permissions to read packages:

```bash
gh auth refresh -h github.com -s read:packages
gh auth token | docker login ghcr.io -u kantord --password-stdin
```


I tested it by running it like so:

```bash
docker run -d -p 3002:3000 --name toolhive-test ghcr.io/stacklok/toolhive-cloud-ui:latest
```

and it works fine!


<img width="1491" height="1312" alt="screenshot-2025-11-13_14-07-02" src="https://github.com/user-attachments/assets/49c19c3d-7967-4ec7-8c7f-f42a45f2d831" />
