### PR TITLE
fix: increase Claude max-turns to 15 for deeper PR reviews

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -36,7 +36,7 @@ jobs:
             - Server vs Client Component usage
             - hey-api integration patterns
             Be concise and actionable - highlight critical issues first.
-          claude_args: "--max-turns 5"
+          claude_args: "--max-turns 15"
 
   # Respond to @claude mentions
   interactive:
@@ -57,4 +57,4 @@ jobs:
         uses: anthropics/claude-code-action@ac1a3207f3f00b4a37e2f3a6f0935733c7c64651 # v1.0
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          claude_args: "--max-turns 5"
+          claude_args: "--max-turns 15"


### PR DESCRIPTION
- Increase from 5 to 15 turns to handle larger PRs
- Allows Claude to complete comprehensive reviews
- Applies to both auto-review and interactive modes