### PR TITLE
fix: helm chart appVersion

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: toolhive-cloud-ui
 description: A Helm chart for ToolHive Cloud UI - Next.js application
 type: application
-version: 0.1.0
-appVersion: "0.1.0"
+version: 0.0.4
+appVersion: "0.0.4"
 keywords:
   - nextjs
   - react


### PR DESCRIPTION
The `0.1.0` doesn't exist yet, it is better to use a version that exist cause the appVersion will be used as fallback in the argocd configuration