### PR TITLE
chore: update swagger and generated files by renovate

### DIFF
--- a/.github/workflows/renovate-post-upgrade.yml
+++ b/.github/workflows/renovate-post-upgrade.yml
@@ -1,0 +1,51 @@
+name: Renovate Post-Upgrade
+
+on:
+    pull_request:
+        branches: [main]
+        paths:
+            - "scripts/generate-swagger.ts"
+
+permissions:
+    contents: write
+    pull-requests: read
+
+jobs:
+    regenerate-client:
+        name: Regenerate API Client
+        runs-on: ubuntu-latest
+        # Only run for Renovate PRs
+        if: github.actor == 'renovate[bot]'
+        steps:
+            - name: Checkout PR branch
+              uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+              with:
+                  ref: ${{ github.head_ref }}
+                  token: ${{ secrets.GITHUB_TOKEN }}
+
+            - name: Setup
+              uses: ./.github/actions/setup
+
+            - name: Generate API Client
+              run: pnpm run generate-client
+
+            - name: Format
+              run: pnpm run format
+
+            - name: Check for changes
+              id: changes
+              run: |
+                  if [[ -n $(git status --porcelain) ]]; then
+                    echo "has_changes=true" >> $GITHUB_OUTPUT
+                  else
+                    echo "has_changes=false" >> $GITHUB_OUTPUT
+                  fi
+
+            - name: Commit and push changes
+              if: steps.changes.outputs.has_changes == 'true'
+              run: |
+                  git config --global user.name "github-actions[bot]"
+                  git config --global user.email "github-actions[bot]@users.noreply.github.com"
+                  git add swagger.json src/generated/
+                  git commit -m "chore: regenerate API client for updated registry server version"
+                  git push

--- a/renovate.json
+++ b/renovate.json
@@ -4,5 +4,20 @@
   "labels": ["dependencies"],
   "prConcurrentLimit": 3,
   "timezone": "Europe/London",
-  "schedule": ["after 01:00 and before 07:00 every weekday"]
+  "schedule": ["after 01:00 and before 07:00 every weekday"],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": ["^scripts/generate-swagger\\.ts$"],
+      "matchStrings": [
+        "renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+) versioning=(?<versioning>\\S+)\\s*\\n\\s*\\*/\\s*\\n.*?=\\s*[\"'](?<currentValue>v[\\d.]+)[\"']"
+      ]
+    }
+  ],
+  "packageRules": [
+    {
+      "description": "Auto-regenerate API client via GitHub Actions workflow",
+      "matchDepNames": ["stacklok/toolhive-registry-server"]
+    }
+  ]
 }

--- a/scripts/generate-swagger.ts
+++ b/scripts/generate-swagger.ts
@@ -3,9 +3,15 @@ import { execSync } from "node:child_process";
 import { writeFile } from "node:fs/promises";
 import * as path from "node:path";
 
+/**
+ * ToolHive Registry Server version.
+ * This is managed by Renovate and updated automatically when new versions are released.
+ * renovate: datasource=github-releases depName=stacklok/toolhive-registry-server versioning=semver
+ */
+const REGISTRY_SERVER_VERSION = "v0.3.9";
+
 (async () => {
-  const url =
-    "https://raw.githubusercontent.com/stacklok/toolhive-registry-server/refs/heads/main/docs/thv-registry-api/swagger.json";
+  const url = `https://raw.githubusercontent.com/stacklok/toolhive-registry-server/refs/tags/${REGISTRY_SERVER_VERSION}/docs/thv-registry-api/swagger.json`;
   const dest = path.resolve("./swagger.json");
 
   console.log(`Fetching OpenAPI spec from: ${url}`);


### PR DESCRIPTION
- renovate updates the toolhive-registry-api version
- gh action run commands for updating swagger and generated files