### PR TITLE
ci: add release orchestrator workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,8 +1,7 @@
 name: Docker Build and Push
 
 on:
-  push:
-    tags: ["v*"]
+  workflow_call:
 
 permissions:
   contents: read

--- a/.github/workflows/release-ui.yml
+++ b/.github/workflows/release-ui.yml
@@ -1,0 +1,32 @@
+# Release orchestrator workflow
+#
+# Triggered when a GitHub Release is published.
+# Calls docker-publish and releaser-helm-chart workflows.
+
+name: Release
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+  packages: write
+  id-token: write
+
+jobs:
+  docker:
+    name: Docker Build and Push
+    uses: ./.github/workflows/docker-publish.yml
+    permissions:
+      contents: read
+      packages: write
+
+  helm:
+    name: Publish Helm Chart
+    needs: docker
+    uses: ./.github/workflows/releaser-helm-chart.yml
+    permissions:
+      contents: read
+      packages: write
+      id-token: write

--- a/.github/workflows/releaser-helm-chart.yml
+++ b/.github/workflows/releaser-helm-chart.yml
@@ -16,7 +16,7 @@
 # Workflow to publish Helm chart to OCI registry (ghcr.io)
 # with Cosign signing for supply chain security.
 #
-# Triggered on version tags (v*) - same as Docker image publish.
+# Triggered when a GitHub Release is published.
 #
 # Usage:
 #   helm install toolhive-cloud-ui oci://ghcr.io/stacklok/toolhive-cloud-ui/toolhive-cloud-ui --version 0.0.7
@@ -30,8 +30,7 @@
 name: Publish Helm Chart to OCI
 
 on:
-    push:
-        tags: ["v*"]
+    workflow_call:
 
 permissions:
     contents: read


### PR DESCRIPTION
## Summary

- Add `release-ui.yml` orchestrator triggered on GitHub Release publish events
- Change `docker-publish.yml` and `releaser-helm-chart.yml` to `workflow_call` (no longer trigger independently)
- Helm chart publishes only after Docker image build succeeds

## Why

Previously, `docker-publish.yml` and `releaser-helm-chart.yml` triggered on `push: tags: ["v*"]`. Tags pushed by the `create-release-tag.yml` workflow used the `GITHUB_TOKEN` credential helper (from `actions/checkout`), which prevented downstream workflows from being triggered.

With `on: release: types: [published]`, the workflows are triggered by the GitHub Release created via `gh release create` (which uses the PAT), resolving the issue.



🤖 Generated with [Claude Code](https://claude.com/claude-code)