### PR TITLE
fix: add version param to filtered registry query

### DIFF
--- a/src/app/catalog/actions.ts
+++ b/src/app/catalog/actions.ts
@@ -67,6 +67,9 @@ export async function getServersByRegistryName(
     path: {
       registryName,
     },
+    query: {
+      version: "latest",
+    },
   });
 
   if (servers.error) {


### PR DESCRIPTION
#349 added the `version=latest` query param to the `getRegistryV01Servers` API call.

But servers with multiple versions were still duplicated when selecting a specific registry.

This fixes by also adding the param to `getRegistryByRegistryNameV01Servers`.

Signed-off-by: Dan Barr <6922515+danbarr@users.noreply.github.com>