### PR TITLE
refactor: handle missing publisher-provided in _meta server

### DIFF
--- a/src/lib/schemas/server-meta.test.ts
+++ b/src/lib/schemas/server-meta.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import type { V0ServerJson } from "@/generated/types.gen";
+import { mockedGetRegistryV01Servers } from "@/mocks/fixtures/registry_v0_1_servers/get";
+import { parseStacklokMeta } from "./server-meta";
+
+const servers = mockedGetRegistryV01Servers.defaultValue.servers ?? [];
+
+function getServerByName(serverName: string): V0ServerJson {
+  const serverEntry = servers.find(
+    (entry) => entry.server?.name === serverName,
+  );
+
+  if (!serverEntry?.server) {
+    throw new Error(`Test fixture server not found: ${serverName}`);
+  }
+
+  return serverEntry.server as V0ServerJson;
+}
+
+const osvServer = getServerByName("com.toolhive.k8s.toolhive-system/osv");
+const googleWorkspaceServer = getServerByName("google/mcp-google-apps");
+
+describe("parseStacklokMeta", () => {
+  it("returns null when stacklok metadata is missing", () => {
+    expect(parseStacklokMeta(googleWorkspaceServer)).toBeNull();
+  });
+
+  it("returns a successful parse result when stacklok metadata is valid", () => {
+    const result = parseStacklokMeta(osvServer);
+
+    expect(result?.success).toBe(true);
+  });
+});

--- a/src/lib/schemas/server-meta.ts
+++ b/src/lib/schemas/server-meta.ts
@@ -31,5 +31,8 @@ export function parseStacklokMeta(server: V0ServerJson) {
     server._meta?.["io.modelcontextprotocol.registry/publisher-provided"]?.[
       "io.github.stacklok"
     ];
+
+  if (!raw) return null;
+
   return stacklokMetaSchema.safeParse(raw);
 }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -13,7 +13,7 @@ export function cn(...inputs: ClassValue[]) {
  */
 export function isVirtualMCPServer(server: V0ServerJson): boolean {
   const result = parseStacklokMeta(server);
-  if (!result.success) return false;
+  if (!result || !result.success) return false;
 
   return Object.values(result.data).some(
     (t) => t.metadata?.kubernetes?.kind === "VirtualMCPServer",
@@ -26,7 +26,7 @@ export function isVirtualMCPServer(server: V0ServerJson): boolean {
  */
 export function getTools(server: V0ServerJson): ServerTool[] {
   const result = parseStacklokMeta(server);
-  if (!result.success) return [];
+  if (!result || !result.success) return [];
 
   return Object.values(result.data).flatMap((t) => t.tool_definitions ?? []);
 }


### PR DESCRIPTION
Handle missing meta info `server._meta?.["io.modelcontextprotocol.registry/publisher-provided"]?.[
      "io.github.stacklok"
    ];` in the server detail

This lead to zod mismatch error type, non a visibile error in the page.

Detail here https://discord.com/channels/1184987096302239844/1450739318376103998/1483027552393101403