### PR TITLE
fix: skip token-refresh redirect in database mode

### DIFF
--- a/src/lib/api-client.test.ts
+++ b/src/lib/api-client.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Hoisted mocks — must be defined before any imports
+const mockRedirect = vi.hoisted(() => vi.fn());
+const mockGetSession = vi.hoisted(() => vi.fn());
+const mockGetAccessToken = vi.hoisted(() => vi.fn());
+const mockIsTokenNearExpiry = vi.hoisted(() => vi.fn());
+const mockIsDatabaseMode = vi.hoisted(() => ({ isDatabaseMode: false }));
+
+vi.mock("next/navigation", () => ({ redirect: mockRedirect }));
+
+vi.mock("next/headers", () => ({
+  headers: vi.fn(() => Promise.resolve(new Headers({ "x-url": "/catalog" }))),
+  cookies: vi.fn(() =>
+    Promise.resolve({ get: vi.fn(), getAll: vi.fn(() => []) }),
+  ),
+}));
+
+vi.mock("@/lib/auth/auth", () => ({
+  auth: {
+    api: { getSession: mockGetSession, getAccessToken: mockGetAccessToken },
+  },
+}));
+
+vi.mock("@/lib/auth/constants", () => ({
+  OIDC_PROVIDER_ID: "oidc",
+}));
+
+vi.mock("@/lib/auth/db", () => mockIsDatabaseMode);
+
+vi.mock("@/lib/auth/utils", () => ({
+  isTokenNearExpiry: mockIsTokenNearExpiry,
+}));
+
+vi.mock("@/generated/client", () => ({
+  createClient: vi.fn(() => ({})),
+  createConfig: vi.fn(() => ({})),
+}));
+
+vi.mock("@/generated/sdk.gen", () => ({}));
+
+import { getAuthenticatedClient } from "./api-client";
+
+const MOCK_SESSION = { user: { id: "user-123" } };
+const MOCK_ACCESS_TOKEN = "mock-access-token";
+
+describe("getAuthenticatedClient", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSession.mockResolvedValue(MOCK_SESSION);
+    mockGetAccessToken.mockResolvedValue({ accessToken: MOCK_ACCESS_TOKEN });
+    mockIsTokenNearExpiry.mockResolvedValue(false);
+    mockIsDatabaseMode.isDatabaseMode = false;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("database mode", () => {
+    it("skips isTokenNearExpiry check and never redirects to token-refresh", async () => {
+      mockIsDatabaseMode.isDatabaseMode = true;
+
+      await getAuthenticatedClient();
+
+      expect(mockIsTokenNearExpiry).not.toHaveBeenCalled();
+      expect(mockRedirect).not.toHaveBeenCalledWith(
+        expect.stringContaining("token-refresh"),
+      );
+    });
+
+    it("proceeds to return the API client", async () => {
+      mockIsDatabaseMode.isDatabaseMode = true;
+
+      const client = await getAuthenticatedClient();
+
+      expect(client).toBeDefined();
+    });
+  });
+
+  describe("cookie mode", () => {
+    it("redirects to token-refresh when token is near expiry", async () => {
+      mockIsDatabaseMode.isDatabaseMode = false;
+      mockIsTokenNearExpiry.mockResolvedValue(true);
+
+      await getAuthenticatedClient();
+
+      expect(mockRedirect).toHaveBeenCalledWith(
+        "/api/auth/token-refresh?redirect=%2Fcatalog",
+      );
+    });
+
+    it("does not redirect when token is fresh", async () => {
+      mockIsDatabaseMode.isDatabaseMode = false;
+      mockIsTokenNearExpiry.mockResolvedValue(false);
+
+      await getAuthenticatedClient();
+
+      expect(mockRedirect).not.toHaveBeenCalledWith(
+        expect.stringContaining("token-refresh"),
+      );
+    });
+  });
+
+  it("redirects to /signin when no session", async () => {
+    mockGetSession.mockResolvedValue(null);
+
+    await getAuthenticatedClient();
+
+    expect(mockRedirect).toHaveBeenCalledWith("/signin");
+  });
+});

--- a/src/lib/api-client.ts
+++ b/src/lib/api-client.ts
@@ -19,6 +19,7 @@ import { createClient, createConfig } from "@/generated/client";
 import * as apiServices from "@/generated/sdk.gen";
 import { auth } from "./auth/auth";
 import { OIDC_PROVIDER_ID } from "./auth/constants";
+import { isDatabaseMode } from "./auth/db";
 import { isTokenNearExpiry } from "./auth/utils";
 
 const MOCK_SCENARIO_COOKIE = "mock-scenario";
@@ -74,16 +75,21 @@ export async function getAuthenticatedClient(accessToken?: string) {
     // the OIDC refresh and saves the rotated refresh token R2), then redirects
     // back. If the token is fresh, call getAccessToken() directly — Better Auth
     // won't refresh (its threshold is 5s), so no Set-Cookie is produced.
-    const nearExpiry = await isTokenNearExpiry();
+    // In database mode, Better Auth stores and refreshes tokens directly in the DB —
+    // no cookie write is needed, so we skip the Route Handler redirect entirely.
+    // The cookie-based preemptive refresh is only needed in stateless (cookie) mode.
+    if (!isDatabaseMode) {
+      const nearExpiry = await isTokenNearExpiry();
 
-    if (nearExpiry) {
-      const currentPath = requestHeaders.get("x-url") || "/catalog";
-      console.log(
-        `[API Client] token near expiry, redirecting to token-refresh | path=${currentPath}`,
-      );
-      redirect(
-        `/api/auth/token-refresh?redirect=${encodeURIComponent(currentPath)}`,
-      );
+      if (nearExpiry) {
+        const currentPath = requestHeaders.get("x-url") || "/catalog";
+        console.log(
+          `[API Client] token near expiry, redirecting to token-refresh | path=${currentPath}`,
+        );
+        redirect(
+          `/api/auth/token-refresh?redirect=${encodeURIComponent(currentPath)}`,
+        );
+      }
     }
 
     let tokenData: {


### PR DESCRIPTION
## Bug

When `DATABASE_URL` is set (database mode), users hit an infinite redirect loop immediately after login:

```
[API Client] token near expiry, redirecting to token-refresh | path=/catalog
[API Client] token near expiry, redirecting to token-refresh | path=/catalog
[API Client] token near expiry, redirecting to token-refresh | path=/catalog
...
```

This results in a **"Too Many Redirects"** browser error and makes the app completely unusable.

### Root cause

In database mode, Better Auth is configured with `storeAccountCookie: false` (`auth.ts:88`), meaning the `account_data` cookie is **never written**. However, `isTokenNearExpiry()` always tries to read that cookie to check token expiry:

```ts
// utils.ts:73
if (!jwe) return true; // No cookie → treat as expired ← always hits this in DB mode!
```

This creates an infinite loop:
1. User visits `/catalog`
2. `getAuthenticatedClient()` → `isTokenNearExpiry()` → no `account_data` cookie (DB mode) → returns `true`
3. Redirect to `/api/auth/token-refresh?redirect=%2Fcatalog`
4. Token refresh succeeds in DB, no cookie written (DB mode), redirect back to `/catalog`
5. Repeat forever

The bug affects **any OIDC provider** (Okta, Azure AD, mock) whenever `DATABASE_URL` is configured — including the default `docker-compose.yaml` which hardcodes `DATABASE_URL`.

### Fix

Guard the preemptive refresh redirect behind `!isDatabaseMode`. In database mode, Better Auth reads and writes tokens directly to the DB — no Route Handler cookie workaround is needed.

The cookie-based redirect to `/api/auth/token-refresh` was introduced specifically to handle the limitation that Server Components cannot write cookies. In database mode this limitation does not apply, so Better Auth handles token refresh transparently via `getAccessToken()`.

## Test plan

- [x] Unit tests added covering DB mode (no redirect) and cookie mode (redirect when near expiry)
- [x] Verify login works with `make compose-down && make compose-up` using Okta + docker-compose
- [x] Verify login still works in cookie mode (no `DATABASE_URL`) with mock OIDC (`pnpm dev`)