### PR TITLE
perf: improve CI and Docker build performance

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -17,3 +17,12 @@ runs:
     - name: Install dependencies
       shell: bash
       run: pnpm install --frozen-lockfile
+
+    - name: Cache Next.js build
+      uses: actions/cache@v4
+      with:
+        path: .next/cache
+        key: nextjs-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}-${{ hashFiles('src/**') }}
+        restore-keys: |
+          nextjs-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}-
+          nextjs-${{ runner.os }}-

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -19,7 +19,7 @@ runs:
       run: pnpm install --frozen-lockfile
 
     - name: Cache Next.js build
-      uses: actions/cache@v4
+      uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
       with:
         path: .next/cache
         key: nextjs-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}-${{ hashFiles('src/**') }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -8,15 +8,14 @@ permissions:
   packages: write
 
 jobs:
-  docker:
-    name: Build and Push Docker Image
+  build-amd64:
+    name: Build amd64
     runs-on: ubuntu-latest
+    outputs:
+      digest: ${{ steps.build.outputs.digest }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
@@ -29,11 +28,62 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
+        id: build
         uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
         with:
           context: .
           push: true
-          platforms: linux/amd64,linux/arm64
-          tags: |
-            ghcr.io/${{ github.repository }}:latest
-            ghcr.io/${{ github.repository }}:${{ github.ref_name }}
+          platforms: linux/amd64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          tags: ghcr.io/${{ github.repository }}
+
+  build-arm64:
+    name: Build arm64
+    runs-on: ubuntu-24.04-arm
+    outputs:
+      digest: ${{ steps.build.outputs.digest }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        id: build
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
+        with:
+          context: .
+          push: true
+          platforms: linux/arm64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          tags: ghcr.io/${{ github.repository }}
+
+  merge:
+    name: Create multi-arch manifest
+    runs-on: ubuntu-latest
+    needs: [build-amd64, build-arm64]
+    steps:
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create manifest and push
+        run: |
+          for TAG in latest ${{ github.ref_name }}; do
+            docker buildx imagetools create -t ghcr.io/${{ github.repository }}:${TAG} \
+              ghcr.io/${{ github.repository }}@${{ needs.build-amd64.outputs.digest }} \
+              ghcr.io/${{ github.repository }}@${{ needs.build-arm64.outputs.digest }}
+          done

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -7,12 +7,26 @@ permissions:
   contents: read
   packages: write
 
+env:
+  REGISTRY: ghcr.io
+  IMAGE: ghcr.io/${{ github.repository }}
+
 jobs:
-  build-amd64:
-    name: Build amd64
-    runs-on: ubuntu-latest
+  build:
+    name: Build ${{ matrix.arch }}
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      matrix:
+        include:
+          - arch: amd64
+            platform: linux/amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            platform: linux/arm64
+            runner: ubuntu-24.04-arm
     outputs:
-      digest: ${{ steps.build.outputs.digest }}
+      digest-amd64: ${{ steps.digest.outputs.digest-amd64 }}
+      digest-arm64: ${{ steps.digest.outputs.digest-arm64 }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -23,7 +37,7 @@ jobs:
       - name: Login to GitHub Container Registry
         uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
         with:
-          registry: ghcr.io
+          registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
@@ -33,57 +47,31 @@ jobs:
         with:
           context: .
           push: true
-          platforms: linux/amd64
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          tags: ghcr.io/${{ github.repository }}
+          platforms: ${{ matrix.platform }}
+          cache-from: type=gha,scope=${{ matrix.arch }}
+          cache-to: type=gha,scope=${{ matrix.arch }},mode=max
+          tags: ${{ env.IMAGE }}
 
-  build-arm64:
-    name: Build arm64
-    runs-on: ubuntu-24.04-arm
-    outputs:
-      digest: ${{ steps.build.outputs.digest }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build and push
-        id: build
-        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
-        with:
-          context: .
-          push: true
-          platforms: linux/arm64
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          tags: ghcr.io/${{ github.repository }}
+      - name: Export digest
+        id: digest
+        run: echo "digest-${{ matrix.arch }}=${{ steps.build.outputs.digest }}" >> "$GITHUB_OUTPUT"
 
   merge:
     name: Create multi-arch manifest
     runs-on: ubuntu-latest
-    needs: [build-amd64, build-arm64]
+    needs: [build]
     steps:
       - name: Login to GitHub Container Registry
         uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
         with:
-          registry: ghcr.io
+          registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create manifest and push
         run: |
           for TAG in latest ${{ github.ref_name }}; do
-            docker buildx imagetools create -t ghcr.io/${{ github.repository }}:${TAG} \
-              ghcr.io/${{ github.repository }}@${{ needs.build-amd64.outputs.digest }} \
-              ghcr.io/${{ github.repository }}@${{ needs.build-arm64.outputs.digest }}
+            docker buildx imagetools create -t ${{ env.IMAGE }}:${TAG} \
+              ${{ env.IMAGE }}@${{ needs.build.outputs.digest-amd64 }} \
+              ${{ env.IMAGE }}@${{ needs.build.outputs.digest-arm64 }}
           done

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -12,21 +12,11 @@ env:
   IMAGE: ghcr.io/${{ github.repository }}
 
 jobs:
-  build:
-    name: Build ${{ matrix.arch }}
-    runs-on: ${{ matrix.runner }}
-    strategy:
-      matrix:
-        include:
-          - arch: amd64
-            platform: linux/amd64
-            runner: ubuntu-latest
-          - arch: arm64
-            platform: linux/arm64
-            runner: ubuntu-24.04-arm
+  build-amd64:
+    name: Build amd64
+    runs-on: ubuntu-latest
     outputs:
-      digest-amd64: ${{ steps.digest.outputs.digest-amd64 }}
-      digest-arm64: ${{ steps.digest.outputs.digest-arm64 }}
+      digest: ${{ steps.build.outputs.digest }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -41,25 +31,51 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push
+      - name: Build and push by digest
         id: build
         uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
         with:
           context: .
           push: true
-          platforms: ${{ matrix.platform }}
-          cache-from: type=gha,scope=${{ matrix.arch }}
-          cache-to: type=gha,scope=${{ matrix.arch }},mode=max
-          tags: ${{ env.IMAGE }}
+          platforms: linux/amd64
+          cache-from: type=gha,scope=amd64
+          cache-to: type=gha,scope=amd64,mode=max
+          outputs: type=image,push-by-digest=true,name=${{ env.IMAGE }},push=true
 
-      - name: Export digest
-        id: digest
-        run: echo "digest-${{ matrix.arch }}=${{ steps.build.outputs.digest }}" >> "$GITHUB_OUTPUT"
+  build-arm64:
+    name: Build arm64
+    runs-on: ubuntu-24.04-arm
+    outputs:
+      digest: ${{ steps.build.outputs.digest }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
+        with:
+          context: .
+          push: true
+          platforms: linux/arm64
+          cache-from: type=gha,scope=arm64
+          cache-to: type=gha,scope=arm64,mode=max
+          outputs: type=image,push-by-digest=true,name=${{ env.IMAGE }},push=true
 
   merge:
     name: Create multi-arch manifest
     runs-on: ubuntu-latest
-    needs: [build]
+    needs: [build-amd64, build-arm64]
     steps:
       - name: Login to GitHub Container Registry
         uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
@@ -72,6 +88,6 @@ jobs:
         run: |
           for TAG in latest ${{ github.ref_name }}; do
             docker buildx imagetools create -t ${{ env.IMAGE }}:${TAG} \
-              ${{ env.IMAGE }}@${{ needs.build.outputs.digest-amd64 }} \
-              ${{ env.IMAGE }}@${{ needs.build.outputs.digest-arm64 }}
+              ${{ env.IMAGE }}@${{ needs.build-amd64.outputs.digest }} \
+              ${{ env.IMAGE }}@${{ needs.build-arm64.outputs.digest }}
           done

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -58,6 +58,12 @@ jobs:
       - name: Setup
         uses: ./.github/actions/setup
 
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+
       - name: Install Playwright browsers
         run: pnpm exec playwright install --with-deps chromium
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -59,7 +59,7 @@ jobs:
         uses: ./.github/actions/setup
 
       - name: Cache Playwright browsers
-        uses: actions/cache@v4
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}

--- a/.github/workflows/type-check.yml
+++ b/.github/workflows/type-check.yml
@@ -19,5 +19,13 @@ jobs:
       - name: Setup
         uses: ./.github/actions/setup
 
+      - name: Cache TypeScript build info
+        uses: actions/cache@v4
+        with:
+          path: tsconfig.tsbuildinfo
+          key: tsbuildinfo-${{ runner.os }}-${{ hashFiles('src/**/*.ts', 'src/**/*.tsx', 'tsconfig.json') }}
+          restore-keys: |
+            tsbuildinfo-${{ runner.os }}-
+
       - name: Run type check
         run: pnpm type-check

--- a/.github/workflows/type-check.yml
+++ b/.github/workflows/type-check.yml
@@ -20,7 +20,7 @@ jobs:
         uses: ./.github/actions/setup
 
       - name: Cache TypeScript build info
-        uses: actions/cache@v4
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
         with:
           path: tsconfig.tsbuildinfo
           key: tsbuildinfo-${{ runner.os }}-${{ hashFiles('src/**/*.ts', 'src/**/*.tsx', 'tsconfig.json') }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,8 @@ WORKDIR /app
 
 # Install dependencies
 COPY package.json pnpm-lock.yaml* ./
-RUN pnpm install --frozen-lockfile
+RUN --mount=type=cache,id=pnpm,target=/root/.local/share/pnpm/store \
+    pnpm install --frozen-lockfile
 
 # Rebuild the source code only when needed
 FROM base AS builder


### PR DESCRIPTION
## Summary

Implements all build performance optimizations from #483:

### Release / Docker build
- **Split multi-arch Docker build into native parallel jobs** — eliminates QEMU emulation for arm64 (8.5 min → ~2 min)
- **Add Docker BuildX GHA cache** to `docker-publish.yml` — saves 2-3 min on subsequent releases
- **Add pnpm cache mount** in Dockerfile — avoids re-downloading packages on every build

### Per-PR CI
- **Cache Playwright browsers** in E2E workflow — saves ~25s per run
- **Cache Next.js build output** (`.next/cache`) in shared setup action — saves 10-15s on incremental builds
- **Cache TypeScript build info** (`.tsbuildinfo`) in type-check workflow — saves ~10s per run

## Expected impact

| | Current | After |
|---|---|---|
| Release Docker build | **8.5 min** | **~1.5-2 min** |
| CI critical path (per-PR) | **3m 51s** | **~3m** |

## Test plan
- [ ] Docker multi-arch build produces correct manifest with both amd64 and arm64
- [ ] CI workflows pass (build, test, lint, type-check, e2e)
- [ ] Caches are populated on first run and restored on subsequent runs
- [ ] Release workflow still pushes correct tags (latest + version)

Closes #483

🤖 Generated with [Claude Code](https://claude.com/claude-code)