### PR TITLE
ci(release): mint GitHub App installation token instead of RELEASE_TOKEN PAT

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -29,6 +29,13 @@ jobs:
     name: Create Release PR
     runs-on: ubuntu-latest
     steps:
+      - name: Generate release app token
+        id: app-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -38,7 +45,7 @@ jobs:
         with:
           releaseo_version: v0.0.3
           bump_type: ${{ inputs.bump_type }}
-          token: ${{ secrets.RELEASE_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           version_files: |
             - file: helm/Chart.yaml
               path: version

--- a/.github/workflows/create-release-tag.yml
+++ b/.github/workflows/create-release-tag.yml
@@ -27,6 +27,13 @@ jobs:
   create-tag:
     runs-on: ubuntu-latest
     steps:
+      - name: Generate release app token
+        id: app-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -126,13 +133,14 @@ jobs:
           echo "Created and pushed tag: $TAG"
 
           # Create GitHub Release (triggers docker-publish.yml and releaser-helm-chart.yml)
-          # Note: Must use PAT (GH_TOKEN) because GITHUB_TOKEN cannot trigger other workflows
+          # Note: Uses a GitHub App installation token rather than GITHUB_TOKEN,
+          # because events from GITHUB_TOKEN cannot trigger downstream workflows.
           gh release create "$TAG" \
             --title "Release $TAG" \
             --generate-notes
           echo "Created GitHub Release: $TAG"
         env:
-          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
 
       - name: Summary
         run: |


### PR DESCRIPTION
## Summary

- Replace the long-lived `RELEASE_TOKEN` PAT with a GitHub App installation token minted via [`actions/create-github-app-token@v3.1.1`](https://github.com/actions/create-github-app-token) in `create-release-pr.yml` and `create-release-tag.yml`.
- Installation tokens are short-lived (1h) and repo-scoped, while still satisfying the constraint that `GITHUB_TOKEN` cannot trigger downstream workflows (e.g. `docker-publish.yml`, `releaser-helm-chart.yml`).

## Pre-merge configuration (required)

The release workflows will fail until the following are configured on this repo:

1. Install the release GitHub App on `stacklok/toolhive-cloud-ui` with repository permissions:
   - `contents: write` (for the tag workflow)
   - `pull-requests: write` (for the release PR workflow)
2. Set repository **variable** `RELEASE_APP_CLIENT_ID` to the app's Client ID.
3. Set repository **secret** `RELEASE_APP_PRIVATE_KEY` to the app's private key (PEM).

## Post-merge cleanup

- Delete the now-unused `RELEASE_TOKEN` repository secret from repo settings.

## Test plan

- [ ] Verify GitHub App is installed on `stacklok/toolhive-cloud-ui` with required permissions.
- [ ] Verify `vars.RELEASE_APP_CLIENT_ID` and `secrets.RELEASE_APP_PRIVATE_KEY` are set on the repo.
- [ ] Trigger `Create Release PR` (patch bump) once via `workflow_dispatch` and confirm the PR is opened by the App actor.
- [ ] Merge that release PR and confirm `create-release-tag.yml` succeeds, the tag is pushed, the GitHub Release is published, and `docker-publish.yml` + `releaser-helm-chart.yml` fire.
- [ ] After successful release, delete the `RELEASE_TOKEN` repo secret.

Refs: stacklok/toolhive#4835

🤖 Generated with [Claude Code](https://claude.com/claude-code)