### PR TITLE
ci: use Toolhive Release App token for release workflows

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -29,8 +29,17 @@ jobs:
     name: Create Release PR
     runs-on: ubuntu-latest
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Create Release PR
         id: release
@@ -38,7 +47,7 @@ jobs:
         with:
           releaseo_version: v0.0.3
           bump_type: ${{ inputs.bump_type }}
-          token: ${{ secrets.RELEASE_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           version_files: |
             - file: helm/Chart.yaml
               path: version

--- a/.github/workflows/create-release-tag.yml
+++ b/.github/workflows/create-release-tag.yml
@@ -27,10 +27,18 @@ jobs:
   create-tag:
     runs-on: ubuntu-latest
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Read version
         id: version
@@ -132,7 +140,7 @@ jobs:
             --generate-notes
           echo "Created GitHub Release: $TAG"
         env:
-          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
 
       - name: Summary
         run: |


### PR DESCRIPTION
## Summary
- Replaces the expired `RELEASE_TOKEN` PAT with short-lived tokens minted by the **Toolhive Release App** in both `create-release-pr.yml` and `create-release-tag.yml`
- Uses `actions/create-github-app-token@v3.2.0` with `vars.RELEASE_APP_CLIENT_ID` (`3534099`) + `secrets.RELEASE_APP_PRIVATE_KEY`
- App tokens are minted per-run (1h TTL) and auto-renew — removes manual PAT rotation as a failure mode

## Context
The latest release attempt failed with `401 Bad credentials` when releaseo tried to create the release PR — the `RELEASE_TOKEN` PAT has expired. The `Toolhive Release App` is already installed on this repo with `Read and write access to code, packages, and pull requests` and its credentials are present in the repo secrets/variables; this PR just wires them in.

Failing run: https://github.com/stacklok/toolhive-cloud-ui/actions/runs/26281193602

## Follow-up after merge
- Trigger `Create Release PR` again to verify the App token flow works end-to-end
- Once confirmed, the `RELEASE_TOKEN` repo secret can be deleted

## Test plan
- [ ] PR CI passes (lint, type-check, etc.)
- [ ] After merge, run `Create Release PR` workflow with `bump_type=patch` and confirm the release PR is created (committer should be `toolhive-release-app[bot]`)
- [ ] Merge the release PR and verify `Create Release Tag` workflow creates the tag and GitHub Release

🤖 Generated with [Claude Code](https://claude.com/claude-code)