### PR TITLE
chore: add needs-triage caller workflow

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -1,0 +1,11 @@
+on:
+  issues:
+    types: [opened, reopened]
+
+permissions:
+  issues: write
+
+jobs:
+  triage:
+    uses: stacklok/.github/.github/workflows/needs-triage.yml@f02175d2fdecb7fc4b23f89aa492fa6b481aa226  # v1
+

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -1,3 +1,5 @@
+name: Needs Triage
+
 on:
   issues:
     types: [opened, reopened]


### PR DESCRIPTION
Wires up the org-wide `needs-triage` reusable workflow. Any new or reopened issue is auto-labeled `needs-triage`; removing the label signals a maintainer has triaged it. Bot-authored issues are skipped.

Caller declares `issues: write` and pins the reusable workflow to a commit SHA (`v1`).