### PR TITLE
chore: pin Node base image to 24.18.0-alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:24-alpine AS base
+FROM node:24.18.0-alpine AS base
 
 # Install dependencies only when needed
 FROM base AS deps

--- a/dev-auth/Dockerfile
+++ b/dev-auth/Dockerfile
@@ -1,5 +1,5 @@
 # OIDC Mock Provider for Development
-FROM node:24-alpine
+FROM node:24.18.0-alpine
 
 WORKDIR /app
 


### PR DESCRIPTION
## What

Pin the Docker base image from the floating `node:24-alpine` tag to the exact `node:24.18.0-alpine` patch release in both `Dockerfile` and `dev-auth/Dockerfile`.

## Why

- **Reproducible builds** — the floating `24-alpine` tag changes under our feet on every rebuild with no PR to track it. Pinning makes the base image explicit and auditable.
- **Verified clean** — a fresh `grype` scan (DB built 2026-06-30) of `node:24.18.0-alpine` reports **0 vulnerabilities** (0 critical / 0 high / 0 medium / 0 low).
  - Ships **Node v24.18.0** (published 2026-06-24), *after* the June 18, 2026 Node.js security release that fixed two HIGH CVEs (CVE-2026-48933 WebCrypto DoS, CVE-2026-48618 TLS hostname normalization).
  - Bundles **tar 7.5.15** (npm 11.16.0) → CVE-2026-26960 resolved.
  - Base **Alpine 3.24.1** — no high/critical apk findings.
- **Stays current automatically** — Renovate's docker manager (already enabled via `config:recommended`) will open reviewable PRs for future 24.x patches, with a 3-day `minimumReleaseAge` guard.

Note: today `24.18.0-alpine`, `24.18-alpine`, and `24-alpine` all resolve to the same digest (`sha256:a0b9bf06...`), so this is a no-op at runtime right now — it only changes how updates are tracked going forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)