### PR TITLE
fix: copy pnpm-workspace.yaml in Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,12 +6,12 @@ FROM base AS deps
 RUN apk add --no-cache libc6-compat
 
 # Install pnpm
-RUN corepack enable && corepack prepare pnpm@10.18.3 --activate
+RUN corepack enable && corepack prepare pnpm@10.33.0 --activate
 
 WORKDIR /app
 
 # Install dependencies
-COPY package.json pnpm-lock.yaml* ./
+COPY package.json pnpm-lock.yaml* pnpm-workspace.yaml ./
 RUN --mount=type=cache,id=pnpm,target=/root/.local/share/pnpm/store \
     pnpm install --frozen-lockfile
 
@@ -19,7 +19,7 @@ RUN --mount=type=cache,id=pnpm,target=/root/.local/share/pnpm/store \
 FROM base AS builder
 
 # Install pnpm
-RUN corepack enable && corepack prepare pnpm@10.18.3 --activate
+RUN corepack enable && corepack prepare pnpm@10.33.0 --activate
 
 WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules


### PR DESCRIPTION
## Problem

The release PR [#520](https://github.com/stacklok/toolhive-cloud-ui/pull/520) (and any Docker build off `main`) fails the **Test Helm Chart** check with:

```
ERR_PNPM_LOCKFILE_CONFIG_MISMATCH  Cannot proceed with the frozen installation.
The current "overrides" configuration doesn't match the value found in the lockfile
```

### Root cause

PR #519 (vulnerability remediation) moved the dependency `overrides` into `pnpm-workspace.yaml` (the pnpm v10 location). The Dockerfile only copies `package.json` and `pnpm-lock.yaml`, so at install time the overrides config is **absent**, while the lockfile still encodes them — pnpm sees a mismatch and aborts `--frozen-lockfile`.

A second, latent issue: the Dockerfile pinned `pnpm@10.18.3` while `package.json` declares `packageManager: pnpm@10.33.0`, so corepack was silently downloading 10.33.0 at build time anyway.

## Fix

- Copy `pnpm-workspace.yaml` alongside `package.json`/`pnpm-lock.yaml` in the `deps` stage so the overrides are present during install.
- Bump the pinned pnpm version to `10.33.0` to match `packageManager`.

## Verification

`pnpm install --frozen-lockfile` now passes the lockfile config check locally (previously failed immediately with the mismatch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)